### PR TITLE
chore: support testnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # debug, info, warn, error
 RUST_LOG=info
 
-# default to home_dir/.kasia-indexer, must be an existing directory with read/write permissions
-# KASIA_INDEXER_DB_PATH=
+# default to home_dir/.kasia-indexer/mainnet, must be an existing directory with read/write permissions
+# KASIA_INDEXER_DB_ROOT=
+
+# default to mainnet, if specified, the network type to use
+NETWORK_TYPE=mainnet
 
 # if not defined, fallback to public kaspa network, if specified, the `ws://{ip}:{port}` node url
 # KASPA_NODE_WBORSH_URL=

--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ Useful commands:
 ```bash
 # debug, info, warn, error
 RUST_LOG=info
-# default to home_dir/.kasia-indexer, must be an existing directory with read/write permissions
-# KASIA_INDEXER_DB_PATH=
+
+# default to home_dir/.kasia-indexer/mainnet, must be an existing directory with read/write permissions
+# KASIA_INDEXER_DB_ROOT=
+
+# default to mainnet, allowed values: mainnet, testnet
+NETWORK_TYPE=mainnet
+
 # if not defined, fallback to public kaspa network, if specified, the `ws://{ip}:{port}` node url
 KASPA_NODE_WBORSH_URL=
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,8 @@ services:
     environment:
       KASPA_NODE_WBORSH_URL: ${KASPA_NODE_WBORSH_URL}
       RUST_LOG: ${RUST_LOG}
-      KASIA_INDEXER_DB_PATH: /app/data
+      KASIA_INDEXER_DB_ROOT: /app/data
+      NETWORK_TYPE: ${NETWORK_TYPE}
       RUST_BACKTRACE: 1
     ports:
       - 1337:8080

--- a/indexer/src/context.rs
+++ b/indexer/src/context.rs
@@ -46,11 +46,6 @@ fn create_rpc_client(network_type: NetworkType) -> anyhow::Result<KaspaRpcClient
     )
     .map_err(|e| anyhow::anyhow!("Failed to create RPC client: {}", e))?;
 
-    info!(
-        "Creating RPC client for network: {:?}, with url {:?}",
-        network_type, url
-    );
-
     Ok(client)
 }
 

--- a/indexer/src/context.rs
+++ b/indexer/src/context.rs
@@ -1,0 +1,106 @@
+use std::{path::PathBuf, str::FromStr, sync::Arc};
+
+use kaspa_wrpc_client::{
+    KaspaRpcClient, WrpcEncoding,
+    prelude::{NetworkId, NetworkType},
+};
+use tracing::info;
+
+struct InnerIndexerContext {
+    db_path: PathBuf,
+    log_path: PathBuf,
+    network_type: NetworkType,
+    rpc_client: KaspaRpcClient,
+}
+
+#[derive(Clone)]
+pub struct IndexerContext {
+    inner: Arc<InnerIndexerContext>,
+}
+
+fn create_rpc_client(network_type: NetworkType) -> anyhow::Result<KaspaRpcClient> {
+    let encoding = WrpcEncoding::Borsh;
+
+    let url = std::env::var("KASPA_NODE_WBORSH_URL").ok();
+    let resolver = if url.is_some() {
+        None
+    } else {
+        Some(kaspa_wrpc_client::Resolver::default())
+    };
+
+    let selected_network = if network_type == NetworkType::Mainnet {
+        Some(NetworkId::new(NetworkType::Mainnet))
+    } else {
+        Some(NetworkId::with_suffix(network_type, 10))
+    };
+
+    let subscription_context = None;
+
+    info!(
+        "Creating RPC client for network: {:?}, with url {:?}",
+        network_type, url
+    );
+
+    let client = KaspaRpcClient::new(
+        encoding,
+        url.as_deref(),
+        resolver,
+        selected_network,
+        subscription_context,
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to create RPC client: {}", e))?;
+
+    info!(
+        "Creating RPC client for network: {:?}, with url {:?}",
+        network_type, url
+    );
+
+    Ok(client)
+}
+
+impl IndexerContext {
+    pub fn try_new() -> anyhow::Result<Self> {
+        let network_type = std::env::var("NETWORK_TYPE")
+            .map(|s| NetworkType::from_str(&s).unwrap_or(NetworkType::Mainnet))
+            .unwrap_or(NetworkType::Mainnet);
+
+        let db_path = std::env::var("KASIA_INDEXER_DB_ROOT")
+            .map(|s| PathBuf::from(s).join(network_type.to_string()))
+            .unwrap_or_else(|_| {
+                std::env::home_dir()
+                    .unwrap()
+                    .join(".kasia-indexer")
+                    .join(network_type.to_string())
+            });
+        let log_path = db_path.join("app_logs");
+
+        std::fs::create_dir_all(&log_path)?;
+
+        let rpc_client = create_rpc_client(network_type)?;
+
+        Ok(Self {
+            inner: Arc::new(InnerIndexerContext {
+                db_path,
+                log_path,
+                network_type,
+                rpc_client,
+            }),
+        })
+    }
+
+    pub fn db_path(&self) -> &PathBuf {
+        &self.inner.db_path
+    }
+
+    pub fn log_path(&self) -> &PathBuf {
+        &self.inner.log_path
+    }
+
+    pub fn network_type(&self) -> NetworkType {
+        self.inner.network_type
+    }
+
+    pub fn rpc_client(&self) -> KaspaRpcClient {
+        self.inner.rpc_client.clone()
+    }
+}

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -26,36 +26,35 @@ use indexer_lib::{
     subscriber::Subscriber,
 };
 use kaspa_wrpc_client::client::{ConnectOptions, ConnectStrategy};
-use kaspa_wrpc_client::prelude::{NetworkId, NetworkType};
-use kaspa_wrpc_client::{KaspaRpcClient, WrpcEncoding};
+use kaspa_wrpc_client::prelude::NetworkType;
 use parking_lot::Mutex;
-use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 use time::macros::format_description;
 use tracing::{error, info};
+
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::filter::Directive;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer};
+use tracing_subscriber::{
+    EnvFilter, Layer, filter::Directive, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+use crate::context::IndexerContext;
 
 mod api;
+mod context;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // ignore faillures as .env might not be present at runtime, and this use-case is tolerated
     dotenv().ok();
 
-    let db_path = std::env::var("KASIA_INDEXER_DB_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| std::env::home_dir().unwrap().join(".kasia-indexer"));
-    let log_path = db_path.join("app_logs");
-    std::fs::create_dir_all(&log_path)?;
-    let _g = init_logs(log_path)?;
-    let config = Config::new(&db_path).max_write_buffer_size(512 * 1024 * 1024);
+    let context = IndexerContext::try_new()?;
+
+    let _g = init_logs(&context)?;
+
+    let config = Config::new(context.db_path()).max_write_buffer_size(512 * 1024 * 1024);
     let tx_keyspace = config.open_transactional()?;
     let reorg_lock = Arc::new(Mutex::new(()));
     // Partitions
@@ -117,8 +116,6 @@ async fn main() -> anyhow::Result<()> {
     let (shutdown_acceptance_worker_tx, shutdown_acceptance_worker_rx) = flume::bounded(1);
     let virtual_daa = Arc::new(AtomicU64::new(0));
 
-    let rpc_client = create_rpc_client()?;
-
     let mut block_worker = BlockProcessor::builder()
         .processed_blocks(FifoSet::new(256))
         .intake(block_intake_rx)
@@ -173,7 +170,7 @@ async fn main() -> anyhow::Result<()> {
         resolver_block_request_rx,
         resolver_sender_request_rx,
         resolver_response_tx.clone(),
-        rpc_client.clone(),
+        context.rpc_client(),
         requests_in_progress.clone(),
     );
 
@@ -216,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
     let (shutdown_selected_chain_syncer_tx, shutdown_selected_chain_syncer_rx) =
         tokio::sync::oneshot::channel();
     let mut selected_chain_syncer = SelectedChainSyncer::new(
-        rpc_client.clone(),
+        context.rpc_client(),
         metadata_partition.clone(),
         block_compact_header_partition.clone(),
         selected_chain_intake_rx,
@@ -228,7 +225,7 @@ async fn main() -> anyhow::Result<()> {
 
     let (shutdown_subscriber_tx, shutdown_subscriber_rx) = tokio::sync::oneshot::channel();
     let mut subscriber = Subscriber::new(
-        rpc_client.clone(),
+        context.rpc_client(),
         block_intake_tx.clone(),
         shutdown_subscriber_rx,
         block_gaps_partition.clone(),
@@ -296,7 +293,8 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::time::sleep(Duration::from_secs(5)).await; // let time to spawn everything
     info!("Connecting to Kaspa node...");
-    rpc_client
+    context
+        .rpc_client()
         .connect(Some(options))
         .await
         .map_err(|e| anyhow::anyhow!("Failed to connect to node: {}", e))?;
@@ -371,37 +369,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn create_rpc_client() -> anyhow::Result<KaspaRpcClient> {
-    let encoding = WrpcEncoding::Borsh;
-
-    let url = std::env::var("KASPA_NODE_WBORSH_URL").ok();
-    let resolver = if url.is_some() {
-        None
-    } else {
-        Some(kaspa_wrpc_client::Resolver::default())
-    };
-
-    let network_type = NetworkType::Mainnet;
-    let selected_network = Some(NetworkId::new(network_type));
-
-    let subscription_context = None;
-
-    info!("Creating RPC client for network: {:?}", network_type);
-
-    let client = KaspaRpcClient::new(
-        encoding,
-        url.as_deref(),
-        resolver,
-        selected_network,
-        subscription_context,
-    )
-    .map_err(|e| anyhow::anyhow!("Failed to create RPC client: {}", e))?;
-    Ok(client)
-}
-
-pub fn init_logs<P: AsRef<Path>>(logs_dir: P) -> anyhow::Result<(WorkerGuard, WorkerGuard)> {
+pub fn init_logs(context: &IndexerContext) -> anyhow::Result<(WorkerGuard, WorkerGuard)> {
     let file_appender = rolling_file::BasicRollingFileAppender::new(
-        logs_dir.as_ref().join("kasia-indexer.mainnet.log"),
+        context.log_path().join(format!(
+            "kasia-indexer.{}.log",
+            NetworkType::to_string(&context.network_type())
+        )),
         rolling_file::RollingConditionBasic::new()
             .max_size(1024 * 1024 * 8)
             .daily(),


### PR DESCRIPTION
env var: `NETWORK_TYPE`, allowed values : `mainnet | testnet`, default: `mainnet`

also moves db data to their own `network` subdir