### PR TITLE
fix(api): indexer network type on address resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -737,6 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -859,6 +861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +897,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1203,7 +1220,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1218,6 +1235,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1538,6 +1561,7 @@ dependencies = [
  "anyhow",
  "axum",
  "dotenv",
+ "envy",
  "faster-hex 0.10.0",
  "fjall",
  "flume",
@@ -1549,6 +1573,7 @@ dependencies = [
  "parking_lot",
  "rolling-file",
  "serde",
+ "serde_with",
  "time",
  "tokio",
  "tower-http",
@@ -1589,6 +1614,17 @@ dependencies = [
  "workflow-core",
  "workflow-rpc",
  "workflow-serializer",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1948,7 +1984,7 @@ dependencies = [
  "derive_more",
  "futures",
  "futures-util",
- "indexmap",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "kaspa-addresses",
  "kaspa-consensus-core",
@@ -2033,7 +2069,7 @@ dependencies = [
  "borsh",
  "cfg-if",
  "hexplay",
- "indexmap",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "kaspa-addresses",
  "kaspa-consensus-core",
@@ -3010,6 +3046,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,6 +3326,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,12 +3498,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -3894,7 +4006,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4151,7 +4263,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap",
+ "indexmap 2.10.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -5204,7 +5316,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap",
+ "indexmap 2.10.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ workflow-core = "0.18.0"
 workflow-rpc = "0.18.0"
 workflow-serializer = "0.18.0"
 dotenv = "0.15.0"
+envy = "0.4"
+serde_with = "3.14.0"
 
 protocol = { path = "protocol" }
 indexer-lib = { path = "indexer-lib" }

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -26,6 +26,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "local-time"]
 utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 workflow-core = { workspace = true }
+serde_with = { workspace = true }
+envy = { workspace = true }
 
 indexer-lib = { path = "../indexer-lib", features = ["utoipa"] }
 

--- a/indexer/src/api/v1.rs
+++ b/indexer/src/api/v1.rs
@@ -73,14 +73,14 @@ impl Api {
             handshake_by_receiver_partition,
             tx_id_to_acceptance_partition.clone(),
             tx_id_to_handshake_partition,
-            context.clone()
+            context.clone(),
         );
 
         let contextual_message_api = ContextualMessageApi::new(
             tx_keyspace.clone(),
             contextual_message_by_sender_partition,
             tx_id_to_acceptance_partition.clone(),
-            context.clone()
+            context.clone(),
         );
 
         let payment_api = PaymentApi::new(
@@ -89,7 +89,7 @@ impl Api {
             payment_by_receiver_partition,
             tx_id_to_payment_partition,
             tx_id_to_acceptance_partition,
-            context.clone()
+            context.clone(),
         );
 
         Self {

--- a/indexer/src/api/v1.rs
+++ b/indexer/src/api/v1.rs
@@ -1,6 +1,7 @@
 use crate::api::v1::contextual_messages::ContextualMessageApi;
 use crate::api::v1::handshakes::HandshakeApi;
 use crate::api::v1::payments::PaymentApi;
+use crate::context::IndexerContext;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::routing::get;
@@ -64,6 +65,7 @@ impl Api {
         tx_id_to_handshake_partition: TxIdToHandshakePartition,
         tx_id_to_payment_partition: TxIdToPaymentPartition,
         metrics: SharedMetrics,
+        context: IndexerContext,
     ) -> Self {
         let handshake_api = HandshakeApi::new(
             tx_keyspace.clone(),
@@ -71,12 +73,14 @@ impl Api {
             handshake_by_receiver_partition,
             tx_id_to_acceptance_partition.clone(),
             tx_id_to_handshake_partition,
+            context.clone()
         );
 
         let contextual_message_api = ContextualMessageApi::new(
             tx_keyspace.clone(),
             contextual_message_by_sender_partition,
             tx_id_to_acceptance_partition.clone(),
+            context.clone()
         );
 
         let payment_api = PaymentApi::new(
@@ -85,6 +89,7 @@ impl Api {
             payment_by_receiver_partition,
             tx_id_to_payment_partition,
             tx_id_to_acceptance_partition,
+            context.clone()
         );
 
         Self {

--- a/indexer/src/api/v1/contextual_messages.rs
+++ b/indexer/src/api/v1/contextual_messages.rs
@@ -1,4 +1,5 @@
 use crate::api::to_rpc_address;
+use crate::context::IndexerContext;
 use anyhow::bail;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -9,7 +10,6 @@ use indexer_lib::database::messages::{
     AddressPayload, contextual_messages::ContextualMessageBySenderPartition,
 };
 use indexer_lib::database::processing::TxIDToAcceptancePartition;
-use kaspa_rpc_core::RpcNetworkType;
 use serde::{Deserialize, Serialize};
 use tokio::task::spawn_blocking;
 use utoipa::{IntoParams, ToSchema};
@@ -19,6 +19,7 @@ pub struct ContextualMessageApi {
     tx_keyspace: fjall::TxKeyspace,
     contextual_message_by_sender_partition: ContextualMessageBySenderPartition,
     tx_id_to_acceptance_partition: TxIDToAcceptancePartition,
+    context: IndexerContext,
 }
 
 impl ContextualMessageApi {
@@ -26,11 +27,13 @@ impl ContextualMessageApi {
         tx_keyspace: fjall::TxKeyspace,
         contextual_message_by_sender_partition: ContextualMessageBySenderPartition,
         tx_id_to_acceptance_partition: TxIDToAcceptancePartition,
+        context: IndexerContext,
     ) -> Self {
         Self {
             tx_keyspace,
             contextual_message_by_sender_partition,
             tx_id_to_acceptance_partition,
+            context,
         }
     }
 
@@ -148,7 +151,7 @@ async fn get_contextual_messages_by_sender(
             let block_time = u64::from_be_bytes(message_key.block_time);
             let tx_id = faster_hex::hex_string(&message_key.tx_id);
 
-            let sender_str = match to_rpc_address(&message_key.sender, RpcNetworkType::Mainnet) {
+            let sender_str = match to_rpc_address(&message_key.sender, state.context.network_type) {
                 Ok(Some(addr)) => addr.to_string(),
                 Ok(None) => bail!("Database consistency error: sender address has EMPTY_VERSION"),
                 Err(e) => bail!("Address conversion error: {}", e),

--- a/indexer/src/api/v1/payments.rs
+++ b/indexer/src/api/v1/payments.rs
@@ -1,4 +1,5 @@
 use crate::api::to_rpc_address;
+use crate::context::IndexerContext;
 use anyhow::bail;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -10,7 +11,6 @@ use indexer_lib::database::messages::{
     payments::{PaymentByReceiverPartition, PaymentBySenderPartition},
 };
 use indexer_lib::database::processing::TxIDToAcceptancePartition;
-use kaspa_rpc_core::RpcNetworkType;
 use serde::{Deserialize, Serialize};
 use tokio::task::spawn_blocking;
 use utoipa::{IntoParams, ToSchema};
@@ -22,6 +22,7 @@ pub struct PaymentApi {
     payment_by_receiver_partition: PaymentByReceiverPartition,
     tx_id_to_payment_partition: TxIdToPaymentPartition,
     tx_id_to_acceptance_partition: TxIDToAcceptancePartition,
+    context: IndexerContext,
 }
 
 impl PaymentApi {
@@ -31,6 +32,7 @@ impl PaymentApi {
         payment_by_receiver_partition: PaymentByReceiverPartition,
         tx_id_to_payment_partition: TxIdToPaymentPartition,
         tx_id_to_acceptance_partition: TxIDToAcceptancePartition,
+        context: IndexerContext,
     ) -> Self {
         Self {
             tx_keyspace,
@@ -38,6 +40,7 @@ impl PaymentApi {
             payment_by_receiver_partition,
             tx_id_to_payment_partition,
             tx_id_to_acceptance_partition,
+            context,
         }
     }
 
@@ -149,7 +152,7 @@ async fn get_payments_by_sender(
                 None => (None, None),
             };
 
-            let receiver_address = match to_rpc_address(&key.receiver, RpcNetworkType::Mainnet) {
+            let receiver_address = match to_rpc_address(&key.receiver, state.context.network_type) {
                 Ok(Some(addr)) => addr.to_string(),
                 Ok(None) => bail!("Database consistency error: receiver address has EMPTY_VERSION"),
                 Err(e) => bail!("Failed to convert receiver address: {}", e),
@@ -262,12 +265,12 @@ async fn get_payments_by_receiver(
                 None => (None, None),
             };
 
-            let sender_address = match to_rpc_address(&sender_payload, RpcNetworkType::Mainnet) {
+            let sender_address = match to_rpc_address(&sender_payload, state.context.network_type) {
                 Ok(opt_addr) => opt_addr.map(|addr| addr.to_string()),
                 Err(e) => bail!("Failed to convert sender address: {}", e),
             };
 
-            let receiver_address = match to_rpc_address(&key.receiver, RpcNetworkType::Mainnet) {
+            let receiver_address = match to_rpc_address(&key.receiver, state.context.network_type) {
                 Ok(Some(addr)) => addr.to_string(),
                 Ok(None) => bail!("Database consistency error: receiver address has EMPTY_VERSION"),
                 Err(e) => bail!("Failed to convert receiver address: {}", e),

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -13,7 +13,7 @@ pub struct IndexerConfig {
     pub rust_log: LevelFilter,
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default = "default_rust_log")]
-    pub rust_file_log: LevelFilter,
+    pub rust_log_file: LevelFilter,
     #[serde(default = "default_kasia_indexer_db_root")]
     pub kasia_indexer_db_root: PathBuf,
     #[serde(default = "default_network_type")]

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -1,0 +1,38 @@
+use std::path::PathBuf;
+
+use kaspa_wrpc_client::prelude::NetworkType;
+use serde::Deserialize;
+use serde_with::{DisplayFromStr, serde_as};
+use tracing::level_filters::LevelFilter;
+
+#[serde_as]
+#[derive(Deserialize, Debug, Clone)]
+pub struct IndexerConfig {
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(default = "default_rust_log")]
+    pub rust_log: LevelFilter,
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(default = "default_rust_log")]
+    pub rust_file_log: LevelFilter,
+    #[serde(default = "default_kasia_indexer_db_root")]
+    pub kasia_indexer_db_root: PathBuf,
+    #[serde(default = "default_network_type")]
+    pub network_type: NetworkType,
+    pub kaspa_node_wborsh_url: Option<String>,
+}
+
+fn default_rust_log() -> LevelFilter {
+    LevelFilter::INFO
+}
+
+fn default_network_type() -> NetworkType {
+    NetworkType::Mainnet
+}
+
+fn default_kasia_indexer_db_root() -> PathBuf {
+    std::env::home_dir().unwrap().join(".kasia-indexer")
+}
+
+pub fn get_indexer_config() -> anyhow::Result<IndexerConfig> {
+    Ok(envy::from_env::<IndexerConfig>()?)
+}

--- a/indexer/src/context.rs
+++ b/indexer/src/context.rs
@@ -1,23 +1,25 @@
-use std::{path::PathBuf, str::FromStr};
-
+use crate::config::IndexerConfig;
 use kaspa_wrpc_client::{
     KaspaRpcClient, WrpcEncoding,
     prelude::{NetworkId, NetworkType},
 };
+use std::path::PathBuf;
 use tracing::info;
 
 #[derive(Clone)]
 pub struct IndexerContext {
+    pub config: IndexerConfig,
     pub db_path: PathBuf,
     pub log_path: PathBuf,
     pub network_type: NetworkType,
     pub rpc_client: KaspaRpcClient,
 }
 
-fn create_rpc_client(network_type: NetworkType) -> anyhow::Result<KaspaRpcClient> {
+fn create_rpc_client(indexer_config: &IndexerConfig) -> anyhow::Result<KaspaRpcClient> {
+    let network_type = indexer_config.network_type;
     let encoding = WrpcEncoding::Borsh;
 
-    let url = std::env::var("KASPA_NODE_WBORSH_URL").ok();
+    let url = indexer_config.kaspa_node_wborsh_url.clone();
     let resolver = if url.is_some() {
         None
     } else {
@@ -49,29 +51,24 @@ fn create_rpc_client(network_type: NetworkType) -> anyhow::Result<KaspaRpcClient
     Ok(client)
 }
 
-pub fn get_indexer_context() -> anyhow::Result<IndexerContext> {
-    let network_type = std::env::var("NETWORK_TYPE")
-        .map(|s| NetworkType::from_str(&s).unwrap_or(NetworkType::Mainnet))
-        .unwrap_or(NetworkType::Mainnet);
+pub fn get_indexer_context(indexer_config: &IndexerConfig) -> anyhow::Result<IndexerContext> {
+    let network_type = indexer_config.network_type;
 
-    let db_path = std::env::var("KASIA_INDEXER_DB_ROOT")
-        .map(|s| PathBuf::from(s).join(network_type.to_string()))
-        .unwrap_or_else(|_| {
-            std::env::home_dir()
-                .unwrap()
-                .join(".kasia-indexer")
-                .join(network_type.to_string())
-        });
+    let db_path = indexer_config
+        .kasia_indexer_db_root
+        .join(network_type.to_string());
+
     let log_path = db_path.join("app_logs");
 
     std::fs::create_dir_all(&log_path)?;
 
-    let rpc_client = create_rpc_client(network_type)?;
+    let rpc_client = create_rpc_client(indexer_config)?;
 
     Ok(IndexerContext {
         db_path,
         log_path,
         network_type,
         rpc_client,
+        config: indexer_config.clone(),
     })
 }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -387,7 +387,7 @@ pub fn init_logs(context: &IndexerContext) -> anyhow::Result<(WorkerGuard, Worke
     let file_subscriber = tracing_subscriber::fmt::layer()
         .with_ansi(false)
         .with_writer(non_blocking_appender)
-        .with_filter(context.config.rust_file_log);
+        .with_filter(context.config.rust_log_file);
     let (non_blocking_appender, guard_stdout) = tracing_appender::non_blocking(std::io::stdout());
     let stdout_subscriber = tracing_subscriber::fmt::layer()
         .with_timer(tracing_subscriber::fmt::time::LocalTime::new(

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
 
     let _g = init_logs(&context)?;
 
-    let config = Config::new(context.db_path).max_write_buffer_size(512 * 1024 * 1024);
+    let config = Config::new(context.clone().db_path).max_write_buffer_size(512 * 1024 * 1024);
     let tx_keyspace = config.open_transactional()?;
     let reorg_lock = Arc::new(Mutex::new(()));
     // Partitions
@@ -282,6 +282,7 @@ async fn main() -> anyhow::Result<()> {
         tx_id_to_handshake_partition,
         tx_id_to_payment_partition,
         metrics.clone(),
+        context.clone()
     );
     let (api_shutdown_tx, api_shutdown_rx) = tokio::sync::oneshot::channel();
     let api_handle = tokio::spawn(api_service.serve("0.0.0.0:8080", api_shutdown_rx));

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -28,21 +28,19 @@ use indexer_lib::{
 use kaspa_wrpc_client::client::{ConnectOptions, ConnectStrategy};
 use kaspa_wrpc_client::prelude::NetworkType;
 use parking_lot::Mutex;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 use time::macros::format_description;
 use tracing::{error, info};
-
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{
-    EnvFilter, Layer, filter::Directive, layer::SubscriberExt, util::SubscriberInitExt,
-};
+use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
+use crate::config::get_indexer_config;
 use crate::context::{IndexerContext, get_indexer_context};
 
 mod api;
+mod config;
 mod context;
 
 #[tokio::main]
@@ -52,7 +50,8 @@ async fn main() -> anyhow::Result<()> {
         .inspect_err(|err| println!("[WARN] reading .env files is failed with err {err}"))
         .ok();
 
-    let context = get_indexer_context()?;
+    let config = get_indexer_config()?;
+    let context = get_indexer_context(&config)?;
 
     let _g = init_logs(&context)?;
 
@@ -282,7 +281,7 @@ async fn main() -> anyhow::Result<()> {
         tx_id_to_handshake_partition,
         tx_id_to_payment_partition,
         metrics.clone(),
-        context.clone()
+        context.clone(),
     );
     let (api_shutdown_tx, api_shutdown_rx) = tokio::sync::oneshot::channel();
     let api_handle = tokio::spawn(api_service.serve("0.0.0.0:8080", api_shutdown_rx));
@@ -388,23 +387,14 @@ pub fn init_logs(context: &IndexerContext) -> anyhow::Result<(WorkerGuard, Worke
     let file_subscriber = tracing_subscriber::fmt::layer()
         .with_ansi(false)
         .with_writer(non_blocking_appender)
-        .with_filter(
-            EnvFilter::builder()
-                .with_env_var("RUST_LOG_FILE")
-                .with_default_directive(Directive::from_str("info")?)
-                .from_env_lossy(),
-        );
+        .with_filter(context.config.rust_file_log);
     let (non_blocking_appender, guard_stdout) = tracing_appender::non_blocking(std::io::stdout());
     let stdout_subscriber = tracing_subscriber::fmt::layer()
         .with_timer(tracing_subscriber::fmt::time::LocalTime::new(
             format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"),
         ))
         .with_writer(non_blocking_appender)
-        .with_filter(
-            EnvFilter::builder()
-                .with_default_directive(Directive::from_str("info")?)
-                .from_env_lossy(),
-        );
+        .with_filter(context.config.rust_log);
 
     tracing_subscriber::registry()
         .with(file_subscriber)


### PR DESCRIPTION
This is an opinionated way of using the indexer network_type defined within the `context`.

We could also have only passed `context.network_type`, and only this field would have been copied within the shared state. But I found that maybe in the future, adding partitions and other shareable stuff within the context would be helpful to avoid copying them down.

I also understand if you prefer being restrictive and declarative. Let me know. :)