### PR TITLE
chore: allow hard recovery when indexer missed acceptance data that have been pruned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "kaspa-addresses"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "borsh",
  "js-sys",
@@ -1772,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-client"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "ahash",
  "cfg-if",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-notify"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-wasm"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "cfg-if",
  "faster-hex 0.9.0",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "kaspa-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "kaspa-hashes"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "kaspa-index-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "kaspa-math"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "borsh",
  "faster-hex 0.9.0",
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "kaspa-merkle"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "kaspa-hashes",
 ]
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "kaspa-mining-errors"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 1.0.69",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "kaspa-muhash"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "kaspa-notify"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-macros"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript-errors"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "secp256k1",
  "thiserror 1.0.69",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "kaspa-utils"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wasm-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wrpc-client"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -32,18 +23,12 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -56,24 +41,27 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayref"
@@ -110,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -122,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -140,7 +128,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-executor",
  "async-io",
  "async-lock",
@@ -151,11 +139,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -164,26 +152,25 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-attributes",
  "async-channel 1.9.0",
@@ -214,9 +201,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -248,9 +235,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
@@ -267,8 +254,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -282,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -293,26 +279,10 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -329,9 +299,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -348,12 +318,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.1"
+name = "block2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "async-channel 2.3.1",
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -362,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.6.4"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -372,11 +351,11 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.6.4"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -387,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -397,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -419,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -431,9 +410,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "byteview"
@@ -443,11 +422,11 @@ checksum = "6236364b88b9b6d0bc181ba374cf1ab55ba3ef97a1cb6f8cddad48a273767fb5"
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -475,18 +454,19 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -496,11 +476,10 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -538,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -584,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -637,9 +616,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -647,22 +626,13 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.7"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
+ "dispatch2",
  "nix 0.30.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -676,17 +646,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.20.11"
+name = "darling"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.114",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -704,13 +670,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.20.11"
+name = "darling_core"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "darling_core 0.20.11",
+ "ident_case",
+ "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.114",
 ]
 
@@ -721,6 +689,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
 ]
@@ -741,35 +720,24 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -787,6 +755,28 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -824,6 +814,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -923,12 +925,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -939,9 +941,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -954,7 +956,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -984,9 +986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fjall"
 version = "2.11.2"
-source = "git+https://github.com/fjall-rs/fjall.git?branch=improve-write-stalling#0ad8037ae4f99c9784d0cd791dd419d4113249fb"
+source = "git+https://github.com/fjall-rs/fjall.git?branch=improve-write-stalling#d6c44f99cd2d01bc730dfd6a0e924ec0b4463771"
 dependencies = [
  "byteorder",
  "byteview",
@@ -1001,13 +1009,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1045,18 +1053,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "fstr"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e4d821c226048ee351e9f7cf8554b5f226ca41b35ffe632eddaa3a8934da2f"
+checksum = "fa16da5411b972ad442cbadc4e55f5acd0b7b31edf64ac34efe34efee5cdbbfb"
 dependencies = [
  "serde",
 ]
@@ -1111,9 +1119,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1175,36 +1183,30 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gloo-timers"
@@ -1226,9 +1228,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1263,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heapless"
@@ -1313,12 +1315,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1359,19 +1360,20 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1379,6 +1381,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1398,14 +1401,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -1429,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1439,7 +1442,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1453,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1466,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1479,11 +1482,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1494,42 +1496,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1545,9 +1543,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1616,7 +1614,7 @@ dependencies = [
  "ringmap",
  "serde",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "utoipa",
@@ -1643,13 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1704,9 +1703,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1741,15 +1740,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1758,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "kaspa-addresses"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "js-sys",
@@ -1773,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-client"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "ahash",
  "cfg-if",
@@ -1802,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1811,7 +1810,7 @@ dependencies = [
  "cfg-if",
  "faster-hex 0.9.0",
  "futures-util",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "itertools 0.13.0",
  "js-sys",
  "kaspa-addresses",
@@ -1839,11 +1838,11 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-notify"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.20",
  "futures",
  "kaspa-consensus-core",
  "kaspa-core",
@@ -1859,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-wasm"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "cfg-if",
  "faster-hex 0.9.0",
@@ -1884,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "kaspa-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1904,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "kaspa-hashes"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -1923,11 +1922,11 @@ dependencies = [
 [[package]]
 name = "kaspa-index-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-trait",
- "derive_more",
+ "derive_more 0.99.20",
  "futures",
  "kaspa-consensus-core",
  "kaspa-hashes",
@@ -1943,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "kaspa-math"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "faster-hex 0.9.0",
@@ -1963,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "kaspa-merkle"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-hashes",
 ]
@@ -1971,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "kaspa-mining-errors"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 1.0.69",
@@ -1980,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "kaspa-muhash"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -1991,12 +1990,12 @@ dependencies = [
 [[package]]
 name = "kaspa-notify"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-trait",
  "borsh",
- "derive_more",
+ "derive_more 0.99.20",
  "futures",
  "futures-util",
  "indexmap",
@@ -2023,13 +2022,13 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-trait",
  "borsh",
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.20",
  "downcast",
  "faster-hex 0.9.0",
  "hex",
@@ -2056,7 +2055,7 @@ dependencies = [
  "serde_nested_with",
  "smallvec",
  "thiserror 1.0.69",
- "uuid 1.17.0",
+ "uuid 1.20.0",
  "wasm-bindgen",
  "workflow-core",
  "workflow-serializer",
@@ -2066,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-macros"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -2079,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2110,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript-errors"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "secp256k1",
  "thiserror 1.0.69",
@@ -2119,10 +2118,10 @@ dependencies = [
 [[package]]
 name = "kaspa-utils"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "arc-swap",
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "borsh",
  "cfg-if",
  "duct",
@@ -2142,14 +2141,14 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "triggered",
- "uuid 1.17.0",
+ "uuid 1.20.0",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kaspa-wasm-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -2161,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wrpc-client"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v1.1.0-rc.2#1a2f98adb39ff91a900170c01fe0beea39751fe2"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2221,33 +2220,24 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
-]
-
-[[package]]
-name = "libz-rs-sys"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
-dependencies = [
- "zlib-rs",
 ]
 
 [[package]]
@@ -2272,33 +2262,32 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
- "serde",
+ "serde_core",
  "value-bag",
 ]
 
@@ -2310,30 +2299,31 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
+checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
 dependencies = [
  "anyhow",
  "arc-swap",
  "chrono",
- "derivative",
+ "derive_more 2.1.1",
  "flate2",
  "fnv",
  "humantime",
  "libc",
  "log",
  "log-mdc",
- "once_cell",
+ "mock_instant",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "thread-id",
  "typemap-ors",
+ "unicode-segmentation",
  "winapi",
 ]
 
@@ -2345,9 +2335,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "2.10.2"
+version = "2.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b6d7475a8dd22e749186968daacf8e2a77932b061b1bd263157987bbfc0c6c"
+checksum = "799399117a2bfb37660e08be33f470958babb98386b04185288d829df362ea15"
 dependencies = [
  "byteorder",
  "crossbeam-skiplist",
@@ -2370,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
 name = "mac_address"
@@ -2409,20 +2399,20 @@ dependencies = [
 
 [[package]]
 name = "manual_future"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943968aefb9b0fdf36cccc03f6cd9d6698b23574ab49eccc185ae6c5cb6ad43e"
+checksum = "b0c72f11f1d8e0c453cbd8042dfb83c2b50384f78a5a5d41019627c5f2062ece"
 dependencies = [
- "futures",
+ "futures-util",
 ]
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2433,9 +2423,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -2469,18 +2459,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "nanorand"
@@ -2488,7 +2485,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2535,28 +2532,27 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -2587,13 +2583,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "objc2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
- "memchr",
+ "objc2-encode",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -2603,9 +2605,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2635,9 +2637,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -2662,19 +2664,13 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2684,9 +2680,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2694,31 +2690,31 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "parse-variants"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbdc211954226807e86041c663407640ff205e514bec8b25731653fd1d3bea82"
+checksum = "84b4d1bb0b90012ce8056bd6bb5168d8de026d633dd592a732da5a25d3f6c74c"
 dependencies = [
  "parse-variants-derive",
 ]
 
 [[package]]
 name = "parse-variants-derive"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27b3870ede76ad9fc5cf19aa770877ad429a8134168a55183bc588acc648ab2"
+checksum = "70d80829147ec6f1b27109c7daaea62fc3a21a0348cdddf22b4093f0c35ab25a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2751,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2786,24 +2782,23 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2825,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.114",
@@ -2835,11 +2830,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -2889,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2906,19 +2901,19 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.14"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
+checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2928,7 +2923,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2936,20 +2931,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2957,23 +2952,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2997,12 +2992,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3022,7 +3017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3031,16 +3026,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3065,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -3078,60 +3073,45 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -3165,7 +3145,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -3176,7 +3156,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3184,12 +3164,12 @@ dependencies = [
 
 [[package]]
 name = "ringmap"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281d65739bbe3b6effa840c6317a7e032127303f62d13b3e18e51482da936e7"
+checksum = "b5009b8c75e4c1c7ff5842d2305eba7f3b76958169493f7a97ba3bd9bcac532d"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3212,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.7.2"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3223,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.7.2"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3236,19 +3216,13 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.7.2"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -3267,22 +3241,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3294,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3304,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3315,15 +3289,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -3336,11 +3310,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3384,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3394,25 +3368,27 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3438,10 +3414,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3450,14 +3435,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3474,12 +3460,13 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3549,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2778001df1384cf20b6dc5a5a90f48da35539885edaaefd887f8d744e939c0b"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
 dependencies = [
  "libc",
  "sigchld",
@@ -3566,9 +3553,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigchld"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1219ef50fc0fdb04fcc243e6aa27f855553434ffafe4fa26554efb78b5b4bf89"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
 dependencies = [
  "libc",
  "os_pipe",
@@ -3587,24 +3574,25 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3617,12 +3605,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3636,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-semaphore"
@@ -3737,15 +3725,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3768,11 +3756,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3788,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3799,12 +3787,12 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "4.2.2"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3818,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -3828,22 +3816,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3851,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3861,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3876,11 +3864,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -3888,14 +3875,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3914,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -3942,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3961,8 +3948,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3975,6 +3962,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3983,8 +3979,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
  "winnow",
 ]
 
@@ -3996,9 +4013,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4012,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -4042,9 +4059,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4054,21 +4071,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4077,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4098,14 +4115,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -4159,21 +4176,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4183,9 +4200,15 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-any-ors"
@@ -4210,13 +4233,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4279,19 +4303,19 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
- "rand 0.9.1",
- "serde",
+ "rand 0.9.2",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4303,9 +4327,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "value-log"
@@ -4383,19 +4407,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4403,29 +4427,17 @@ dependencies = [
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4434,9 +4446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4444,31 +4456,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4490,14 +4502,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4520,11 +4532,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4557,14 +4569,14 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result 0.3.4",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -4581,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4603,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4614,18 +4626,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.3.4",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -4640,18 +4652,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -4689,7 +4701,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4725,18 +4746,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4753,9 +4775,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4771,9 +4793,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4789,9 +4811,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -4801,9 +4823,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4819,9 +4841,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4837,9 +4859,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4855,9 +4877,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4873,27 +4895,24 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "workflow-core"
@@ -4901,7 +4920,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d67bbe225ea90aa6979167f28935275506696ac867661e218893d3a42e1666"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-std",
  "borsh",
  "bs58",
@@ -4910,7 +4929,7 @@ dependencies = [
  "dirs",
  "faster-hex 0.9.0",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "instant",
  "js-sys",
  "rand 0.8.5",
@@ -5032,7 +5051,7 @@ dependencies = [
  "downcast-rs",
  "futures",
  "futures-util",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "manual_future",
  "rand 0.8.5",
  "serde",
@@ -5143,7 +5162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "515483a047477c91b5142e1090cce0afc21a0139d9c0c06ea42f0d3dbf3a6fcd"
 dependencies = [
  "ahash",
- "async-channel 2.3.1",
+ "async-channel 2.5.0",
  "async-std",
  "async-trait",
  "cfg-if",
@@ -5167,9 +5186,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xxhash-rust"
@@ -5179,11 +5198,10 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -5191,9 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5203,18 +5221,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5244,15 +5262,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5261,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5272,9 +5290,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5297,15 +5315,21 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
+name = "zmij"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
 
 [[package]]
 name = "zopfli"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,12 @@ fjall = { version = "2.11.2", default-features = false, features = [
 flume = "0.11.1"
 fstr = "0.2.13"
 futures-util = "0.3.31"
-#kaspa-addresses = "1.*"
-#kaspa-consensus-core = "1.*"
-#kaspa-rpc-core = "1.*"
-#kaspa-txscript = "1.*"
-#kaspa-wrpc-client = "1.*"
-kaspa-addresses = "1.1.0-rc.2"
-kaspa-consensus-core = "1.1.0-rc.2"
-kaspa-rpc-core = "1.1.0-rc.2"
-kaspa-txscript = "1.1.0-rc.2"
-kaspa-wrpc-client = "1.1.0-rc.2"
+kaspa-addresses = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
+kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
+kaspa-math = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
+kaspa-rpc-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
+kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
+kaspa-wrpc-client = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
 rayon = "1.11.0"
 ringmap = "0.1.4"
 rolling-file = "0.2.0"
@@ -55,11 +51,5 @@ indexer-actors = { path = "indexer-actors" }
 indexer-db = { path = "indexer-db" }
 
 [patch.crates-io]
-kaspa-addresses = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
-kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
-kaspa-math = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
-kaspa-rpc-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
-kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
-kaspa-wrpc-client = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
 
 fjall = { git = "https://github.com/fjall-rs/fjall.git", branch = "improve-write-stalling" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,16 @@ fjall = { version = "2.11.2", default-features = false, features = [
 flume = "0.11.1"
 fstr = "0.2.13"
 futures-util = "0.3.31"
-kaspa-addresses = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
-kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
-kaspa-math = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
-kaspa-rpc-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
-kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
-kaspa-wrpc-client = { git = "https://github.com/kaspanet/rusty-kaspa.git", branch = "master" }
+#kaspa-addresses = "1.*"
+#kaspa-consensus-core = "1.*"
+#kaspa-rpc-core = "1.*"
+#kaspa-txscript = "1.*"
+#kaspa-wrpc-client = "1.*"
+kaspa-addresses = "1.1.0-rc.2"
+kaspa-consensus-core = "1.1.0-rc.2"
+kaspa-rpc-core = "1.1.0-rc.2"
+kaspa-txscript = "1.1.0-rc.2"
+kaspa-wrpc-client = "1.1.0-rc.2"
 rayon = "1.11.0"
 ringmap = "0.1.4"
 rolling-file = "0.2.0"
@@ -51,5 +55,11 @@ indexer-actors = { path = "indexer-actors" }
 indexer-db = { path = "indexer-db" }
 
 [patch.crates-io]
+kaspa-addresses = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
+kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
+kaspa-math = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
+kaspa-rpc-core = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
+kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
+kaspa-wrpc-client = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v1.1.0-rc.2" }
 
 fjall = { git = "https://github.com/fjall-rs/fjall.git", branch = "improve-write-stalling" }

--- a/indexer-actors/src/block_gap_filler.rs
+++ b/indexer-actors/src/block_gap_filler.rs
@@ -74,6 +74,14 @@ impl BlockGapFiller {
                 }))
                 .await?;
             match rx.await? {
+                Err(RequestError::Pruned) => {
+                    self.gap_result_tx
+                        .send_async(GapFillingProgress::Pruned {
+                            target: self.target_block,
+                        })
+                        .await?;
+                    return Ok(());
+                }
                 Err(RequestError::RpcError(err)) => {
                     self.gap_result_tx
                         .send_async(GapFillingProgress::Error {

--- a/indexer-actors/src/block_processor.rs
+++ b/indexer-actors/src/block_processor.rs
@@ -214,62 +214,61 @@ impl BlockProcessor {
                     info!(to = %to.to_hex_64(), "Gap filler hit pruned data");
                     let from = gaps_fillers.remove(&to).map(|(from, _)| from);
                     self.gaps_filling_in_progress -= 1;
-                    if !is_shutdown {
-                        if let (Some(pruning_point), Some(from_block)) =
+                    if !is_shutdown
+                        && let (Some(pruning_point), Some(from_block)) =
                             (pruning_point_at_connect, from)
-                        {
-                            if from_block != pruning_point {
-                                info!(
-                                    from = %from_block.to_hex_64(),
-                                    pp = %pruning_point.to_hex_64(),
-                                    to = %to.to_hex_64(),
-                                    "Gap fill failed, retrying from pruning point"
-                                );
-                                loop {
-                                    let mut wtx = self.tx_keyspace.write_tx()?;
+                        && from_block != pruning_point
+                    {
+                        info!(
+                            from = %from_block.to_hex_64(),
+                            pp = %pruning_point.to_hex_64(),
+                            to = %to.to_hex_64(),
+                            "Gap fill failed, retrying from pruning point"
+                        );
+                        loop {
+                            let mut wtx = self.tx_keyspace.write_tx()?;
 
-                                    // change the gap in case of a recovery, starting from pruning point
-                                    // TODO: this isn't reliable as pp might move on the next block filling task
-                                    //       find a way to either trigger is now (synced) or maybe let a handler fetch pp on the fly
-                                    //     => important thing is to stop trying to fill gaps we cannot fill (lost)
-                                    self.blocks_gap_partition.remove_gap_wtx(&mut wtx, &to);
-                                    self.blocks_gap_partition.add_gap_wtx(
-                                        &mut wtx,
-                                        indexer_db::headers::block_gaps::BlockGap {
-                                            from: pruning_point,
-                                            to,
-                                        },
-                                    );
-                                    if wtx.commit()?.is_ok() {
-                                        break;
-                                    } else {
-                                        warn!("Conflict detected while updating gap after error");
-                                    }
-                                }
-
-                                let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel();
-                                self.runtime_handle.spawn({
-                                    let filler = BlockGapFiller::new(
-                                        pruning_point,
-                                        to,
-                                        self.gap_result_tx.clone(),
-                                        self.command_tx.clone(),
-                                        interrupt_rx,
-                                    );
-                                    async move {
-                                        _ = filler.sync().await.inspect_err(
-                                            |err| error!(%err, "Error in block gap filler"),
-                                        );
-                                    }
-                                });
-                                gaps_fillers.insert(to, (pruning_point, interrupt_tx));
-                                self.gaps_filling_in_progress += 1;
-                                info!(
-                                    self.gaps_filling_in_progress,
-                                    "Retrying gap filling from pruning point"
-                                );
+                            // change the gap in case of a recovery, starting from pruning point
+                            // TODO: this isn't reliable as pp might move on the next block filling task
+                            //       find a way to either trigger is now (synced) or maybe let a handler fetch pp on the fly
+                            //     => important thing is to stop trying to fill gaps we cannot fill (lost)
+                            self.blocks_gap_partition.remove_gap_wtx(&mut wtx, &to);
+                            self.blocks_gap_partition.add_gap_wtx(
+                                &mut wtx,
+                                indexer_db::headers::block_gaps::BlockGap {
+                                    from: pruning_point,
+                                    to,
+                                },
+                            );
+                            if wtx.commit()?.is_ok() {
+                                break;
+                            } else {
+                                warn!("Conflict detected while updating gap after error");
                             }
                         }
+
+                        let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel();
+                        self.runtime_handle.spawn({
+                            let filler = BlockGapFiller::new(
+                                pruning_point,
+                                to,
+                                self.gap_result_tx.clone(),
+                                self.command_tx.clone(),
+                                interrupt_rx,
+                            );
+                            async move {
+                                _ = filler
+                                    .sync()
+                                    .await
+                                    .inspect_err(|err| error!(%err, "Error in block gap filler"));
+                            }
+                        });
+                        gaps_fillers.insert(to, (pruning_point, interrupt_tx));
+                        self.gaps_filling_in_progress += 1;
+                        info!(
+                            self.gaps_filling_in_progress,
+                            "Retrying gap filling from pruning point"
+                        );
                     }
                 }
                 NotificationOrGapResult::GapFilling(GapFillingProgress::Update {

--- a/indexer-actors/src/block_processor.rs
+++ b/indexer-actors/src/block_processor.rs
@@ -76,21 +76,28 @@ impl BlockProcessor {
     pub fn process(&mut self) -> anyhow::Result<()> {
         info!("Block worker started");
         let mut has_first_connect = false;
-        let mut gaps_fillers = HashMap::new();
+        let mut gaps_fillers: HashMap<[u8; 32], ([u8; 32], tokio::sync::oneshot::Sender<()>)> =
+            HashMap::new();
         let mut is_shutdown = false;
         let mut last_processed_block: Option<[u8; 32]> = None;
+        let mut pruning_point_at_connect: Option<[u8; 32]> = None;
         // let mut gaps_filling_in_progress = 0;
         loop {
             match self.select_input()? {
                 NotificationOrGapResult::Notification(BlockNotification::Connected {
                     sink,
-                    pp,
+                    pp_header,
                 }) => {
-                    info!(sink = %sink.to_hex_64(), pp = %pp.to_hex_64(), "Received connection notification");
+                    info!(
+                        sink = %sink.to_hex_64(),
+                        pp = %pp_header.block_hash.to_hex_64(),
+                        "Received connection notification"
+                    );
+                    pruning_point_at_connect = Some(pp_header.block_hash);
                     if !has_first_connect {
                         has_first_connect = true;
                         info!("Handling first connection");
-                        let gaps = self.handle_first_connect(sink, pp)?;
+                        let gaps = self.handle_first_connect(sink, pp_header.block_hash)?;
                         info!(gap_count = gaps.len(), "Found gaps to fill");
                         gaps_fillers = gaps
                             .into_iter()
@@ -110,7 +117,7 @@ impl BlockProcessor {
                                         );
                                     }
                                 });
-                                (gap.to_block, interrupt_tx)
+                                (gap.to_block, (gap.from_block, interrupt_tx))
                             })
                             .collect();
                         self.gaps_filling_in_progress = gaps_fillers.len();
@@ -134,33 +141,33 @@ impl BlockProcessor {
                                     .inspect_err(|err| error!(%err, "Error in block gap filler"));
                             }
                         });
-                        gaps_fillers.insert(sink, interrupt_tx);
+                        gaps_fillers.insert(sink, (last_processed_block, interrupt_tx));
                         self.gaps_filling_in_progress += 1;
                         info!(self.gaps_filling_in_progress, "New block gap added");
                     }
                 }
                 NotificationOrGapResult::Notification(BlockNotification::Disconnected) => {
                     info!("Received disconnection notification, stopping gap fillers");
-                    std::mem::take(&mut gaps_fillers)
-                        .into_iter()
-                        .for_each(|(_to, interrupt_tx)| {
+                    std::mem::take(&mut gaps_fillers).into_iter().for_each(
+                        |(_to, (_from, interrupt_tx))| {
                             info!("send interruption signal");
                             let _ = interrupt_tx.send(()).inspect_err(|_err| {
                                 error!("Error sending interrupt to block gap filler")
                             });
-                        })
+                        },
+                    )
                 }
                 NotificationOrGapResult::Notification(BlockNotification::Shutdown) => {
                     info!("Received shutdown notification");
                     is_shutdown = true;
-                    std::mem::take(&mut gaps_fillers)
-                        .into_iter()
-                        .for_each(|(_to, interrupt_tx)| {
+                    std::mem::take(&mut gaps_fillers).into_iter().for_each(
+                        |(_to, (_from, interrupt_tx))| {
                             info!("send interruption signal");
                             let _ = interrupt_tx.send(()).inspect_err(|_err| {
                                 error!("Error sending interrupt to block gap filler")
                             });
-                        })
+                        },
+                    )
                 }
                 NotificationOrGapResult::Notification(BlockNotification::Notification(block)) => {
                     let hash = block.header.hash.as_bytes();
@@ -202,6 +209,68 @@ impl BlockProcessor {
                     error!(to = %to.to_hex_64(), %err, "Error in block gap filler");
                     gaps_fillers.remove(&to);
                     self.gaps_filling_in_progress -= 1;
+                }
+                NotificationOrGapResult::GapFilling(GapFillingProgress::Pruned { target: to }) => {
+                    info!(to = %to.to_hex_64(), "Gap filler hit pruned data");
+                    let from = gaps_fillers.remove(&to).map(|(from, _)| from);
+                    self.gaps_filling_in_progress -= 1;
+                    if !is_shutdown {
+                        if let (Some(pruning_point), Some(from_block)) =
+                            (pruning_point_at_connect, from)
+                        {
+                            if from_block != pruning_point {
+                                info!(
+                                    from = %from_block.to_hex_64(),
+                                    pp = %pruning_point.to_hex_64(),
+                                    to = %to.to_hex_64(),
+                                    "Gap fill failed, retrying from pruning point"
+                                );
+                                loop {
+                                    let mut wtx = self.tx_keyspace.write_tx()?;
+
+                                    // change the gap in case of a recovery, starting from pruning point
+                                    // TODO: this isn't reliable as pp might move on the next block filling task
+                                    //       find a way to either trigger is now (synced) or maybe let a handler fetch pp on the fly
+                                    //     => important thing is to stop trying to fill gaps we cannot fill (lost)
+                                    self.blocks_gap_partition.remove_gap_wtx(&mut wtx, &to);
+                                    self.blocks_gap_partition.add_gap_wtx(
+                                        &mut wtx,
+                                        indexer_db::headers::block_gaps::BlockGap {
+                                            from: pruning_point,
+                                            to,
+                                        },
+                                    );
+                                    if wtx.commit()?.is_ok() {
+                                        break;
+                                    } else {
+                                        warn!("Conflict detected while updating gap after error");
+                                    }
+                                }
+
+                                let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel();
+                                self.runtime_handle.spawn({
+                                    let filler = BlockGapFiller::new(
+                                        pruning_point,
+                                        to,
+                                        self.gap_result_tx.clone(),
+                                        self.command_tx.clone(),
+                                        interrupt_rx,
+                                    );
+                                    async move {
+                                        _ = filler.sync().await.inspect_err(
+                                            |err| error!(%err, "Error in block gap filler"),
+                                        );
+                                    }
+                                });
+                                gaps_fillers.insert(to, (pruning_point, interrupt_tx));
+                                self.gaps_filling_in_progress += 1;
+                                info!(
+                                    self.gaps_filling_in_progress,
+                                    "Retrying gap filling from pruning point"
+                                );
+                            }
+                        }
+                    }
                 }
                 NotificationOrGapResult::GapFilling(GapFillingProgress::Update {
                     target: to,

--- a/indexer-actors/src/block_processor/message.rs
+++ b/indexer-actors/src/block_processor/message.rs
@@ -1,9 +1,13 @@
+use crate::virtual_chain_processor::CompactHeader;
 use kaspa_rpc_core::RpcBlock;
 use std::sync::Arc;
 
 #[derive(Debug)]
 pub enum BlockNotification {
-    Connected { sink: [u8; 32], pp: [u8; 32] },
+    Connected {
+        sink: [u8; 32],
+        pp_header: CompactHeader,
+    },
     Disconnected,
     Shutdown,
     Notification(Arc<RpcBlock>),
@@ -21,6 +25,9 @@ pub enum GapFillingProgress {
     Finished {
         target: [u8; 32],
         blocks: Vec<RpcBlock>,
+    },
+    Pruned {
+        target: [u8; 32],
     },
     Error {
         target: [u8; 32],

--- a/indexer-actors/src/data_source.rs
+++ b/indexer-actors/src/data_source.rs
@@ -1,4 +1,5 @@
 use crate::block_processor::BlockNotification;
+use crate::virtual_chain_processor::CompactHeader;
 use crate::virtual_chain_processor::RealTimeVccNotification;
 use anyhow::Context;
 use futures_util::future::FutureExt;
@@ -149,13 +150,18 @@ impl DataSource {
             .await?
             .header
             .blue_work;
+        let pp_block = self
+            .rpc_client
+            .get_block(info.pruning_point_hash, false)
+            .await?;
+        let pp_header: CompactHeader = (&pp_block.header).into();
         self.connected = true;
         let pair = futures_util::future::join(
             async {
                 self.block_sender
                     .send_async(BlockNotification::Connected {
                         sink: info.sink.as_bytes(),
-                        pp: info.pruning_point_hash.as_bytes(),
+                        pp_header,
                     })
                     .await
                     .context("block handler connect send failed")
@@ -165,7 +171,7 @@ impl DataSource {
                     .send_async(RealTimeVccNotification::Connected {
                         sink: info.sink.as_bytes(),
                         sink_blue_work,
-                        pp: info.pruning_point_hash.as_bytes(),
+                        pp_header,
                     })
                     .await
                     .context("vcc handler connect send failed")
@@ -448,8 +454,13 @@ impl DataSource {
                                 });
                             }
                             Err(e) => {
+                                let err = if is_pruned_error(&e) {
+                                    RequestError::Pruned
+                                } else {
+                                    RequestError::RpcError(e)
+                                };
                                 _ = response_channel
-                                    .send(Err(e.into()))
+                                    .send(Err(err))
                                     .inspect_err(|_err| error!("sending blocks result err"));
                             }
                         }
@@ -521,8 +532,13 @@ impl DataSource {
                                     });
                             }
                             Err(e) => {
+                                let err = if is_pruned_error(&e) {
+                                    RequestError::Pruned
+                                } else {
+                                    RequestError::RpcError(e)
+                                };
                                 _ = response_channel
-                                    .send(Err(e.into()))
+                                    .send(Err(err))
                                     .inspect_err(|_err| error!("sending vcc result err"));
                             }
                         }
@@ -564,6 +580,14 @@ pub enum Request {
 pub enum RequestError {
     #[error("Shutting down")]
     ShuttingDown,
+    #[error("Pruned block data unavailable")]
+    Pruned,
     #[error("RPC error: {0}")]
     RpcError(#[from] workflow_rpc::client::error::Error),
+}
+
+fn is_pruned_error(err: &workflow_rpc::client::error::Error) -> bool {
+    err.to_string()
+        .to_lowercase()
+        .contains("cannot find header")
 }

--- a/indexer-actors/src/virtual_chain_processor.rs
+++ b/indexer-actors/src/virtual_chain_processor.rs
@@ -4,6 +4,7 @@ use crate::data_source::{Command, Request};
 use crate::util::ToHex64;
 use crate::virtual_chain_syncer::{NotificationAck, VirtualChainSyncer};
 use fjall::{TxKeyspace, WriteTransaction};
+use indexer_db::headers::daa_index::DaaIndexPartition;
 use indexer_db::messages::contextual_message::{
     ContextualMessageBySenderKey, ContextualMessageBySenderPartition,
 };
@@ -16,6 +17,9 @@ use indexer_db::messages::payment::{
 };
 use indexer_db::messages::self_stash::{SelfStashByOwnerPartition, SelfStashKeyByOwner};
 use indexer_db::metadata::{Cursor as DbCursor, MetadataPartition};
+use indexer_db::processing::acceptance_gaps::{
+    AcceptanceGap as DbAcceptanceGap, AcceptanceGapsPartition,
+};
 use indexer_db::processing::accepting_block_to_txs::AcceptingBlockToTxIDPartition;
 use indexer_db::processing::pending_senders::{
     PendingResolutionKey, PendingSenderResolutionPartition,
@@ -47,6 +51,8 @@ pub struct VirtualProcessor {
 
     tx_keyspace: TxKeyspace,
     metadata_partition: MetadataPartition,
+    acceptance_gaps_partition: AcceptanceGapsPartition,
+    daa_index_partition: DaaIndexPartition,
     tx_id_to_acceptance_partition: TxIDToAcceptancePartition,
     accepting_block_to_tx_id_partition: AcceptingBlockToTxIDPartition,
     pending_sender_resolution_partition: PendingSenderResolutionPartition,
@@ -82,6 +88,8 @@ struct StateShared {
     processed_blocks: ringmap::RingMap<[u8; 32], (DaaScore, BlueWorkType)>, // when we get synced keep only blocks in ~10 mins interval. realloc it
     realtime_queue_vcc: VecDeque<VirtualChainChangedNotification>, // perform realloc when sync is finished if queue is too big
     processed_time_or_warn: std::time::Instant,
+    /// initialized only once on connect, used in case of recovery when we missed past pp data
+    pruning_point_at_startup: Option<CompactHeader>,
 }
 
 impl StateShared {
@@ -108,6 +116,7 @@ impl StateShared {
             processed_blocks,
             realtime_queue_vcc: VecDeque::new(),
             processed_time_or_warn: Instant::now(),
+            pruning_point_at_startup: None,
         }
     }
 }
@@ -142,10 +151,14 @@ impl VirtualProcessor {
                 ProcessedBlockOrVccOrSyncer::Vcc(RealTimeVccNotification::Connected {
                     sink,
                     sink_blue_work,
-                    pp,
+                    pp_header,
                 }) => {
-                    info!(sink = %sink.to_hex_64(), pp = %pp.to_hex_64(), "Received VCC connection notification");
-                    self.handle_connect(state, sink, sink_blue_work, pp)?;
+                    info!(
+                        sink = %sink.to_hex_64(),
+                        pp = %pp_header.block_hash.to_hex_64(),
+                        "Received VCC connection notification"
+                    );
+                    self.handle_connect(state, sink, sink_blue_work, pp_header)?;
                 }
                 ProcessedBlockOrVccOrSyncer::Vcc(RealTimeVccNotification::Disconnected) => {
                     info!("Received VCC disconnection notification");
@@ -158,6 +171,24 @@ impl VirtualProcessor {
                     debug!(syncer_id, "Received syncer virtual chain notification");
                     self.handle_syncer_vc(state, syncer_id, virtual_chain)?;
                     // todo: process real time queue if get synced
+                }
+                ProcessedBlockOrVccOrSyncer::Syncer(SyncVccNotification::Pruned {
+                    syncer_id,
+                    from,
+                    err,
+                }) => {
+                    warn!(
+                        syncer_id,
+                        from = %from.to_hex_64(),
+                        error = %err,
+                        "Syncer reported pruned data"
+                    );
+                    let cont = self.handle_syncer_pruned(state, syncer_id, from)?;
+                    if cont {
+                        continue;
+                    } else {
+                        return Ok(());
+                    }
                 }
                 ProcessedBlockOrVccOrSyncer::Vcc(RealTimeVccNotification::Shutdown) => {
                     info!("Received VCC shutdown notification");
@@ -216,8 +247,9 @@ impl VirtualProcessor {
         state: &mut State,
         sink: [u8; 32],
         sink_blue_work: BlueWorkType,
-        pp: [u8; 32],
+        pp_header: CompactHeader,
     ) -> anyhow::Result<()> {
+        state.shared_state.pruning_point_at_startup = Some(pp_header);
         debug!("Handling virtual chain connection, requesting all pending senders");
         match &mut state.sync_state {
             SyncState::Initial => {
@@ -238,10 +270,11 @@ impl VirtualProcessor {
                 debug!(last_accepting_block = ?last_accepting_block, "Checked last accepting block from database");
                 match last_accepting_block {
                     None => {
-                        info!(pp = %pp.to_hex_64(), "No last accepting block, starting sync from pruning point");
-                        let syncer = self.spawn_syncer(0, pp);
+                        let pp_hash = pp_header.block_hash;
+                        info!(pp = %pp_hash.to_hex_64(), "No last accepting block, starting sync from pruning point");
+                        let syncer = self.spawn_syncer(0, pp_hash);
                         state.sync_state = SyncState::Syncing {
-                            last_accepting_block: (pp, Default::default()),
+                            last_accepting_block: (pp_hash, Default::default()),
                             syncer,
                             syncer_id: 0,
                             target_block: (sink, sink_blue_work),
@@ -455,6 +488,176 @@ impl VirtualProcessor {
             // ignore previous syncers
             _ => Ok(true),
         }
+    }
+
+    /// If: vcc is syncing, syncer is noted as in progress by state, app isn't shutting down
+    ///     pruning point is known
+    /// Then, try to recover:
+    ///     record the acceptance gap, clear acceptance data in that range,
+    ///     and start a new vcc syncer from pp
+    /// TODO: same as block processor: this isn't reliable as pp might move on the next block filling task
+    fn handle_syncer_pruned(
+        &self,
+        state: &mut State,
+        syncer_id: u64,
+        from: [u8; 32],
+    ) -> anyhow::Result<Continue> {
+        let (current_syncer_id, (target_hash, target_blue_work)) = match &state.sync_state {
+            SyncState::Syncing {
+                syncer_id,
+                target_block,
+                ..
+            } => (*syncer_id, *target_block),
+            _ => return Ok(true),
+        };
+        if syncer_id != current_syncer_id {
+            return Ok(true);
+        }
+        if state.shared_state.shutting_down {
+            return Ok(false);
+        }
+        let Some(pruning_point_header) = state.shared_state.pruning_point_at_startup else {
+            anyhow::bail!("Cannot recover from pruned sync: pruning point header missing");
+        };
+
+        let latest_cursor = self
+            .metadata_partition
+            .get_latest_accepting_block_cursor()?;
+        let Some(cursor) = latest_cursor else {
+            anyhow::bail!("Cannot recover from pruned sync: latest accepting cursor missing");
+        };
+        let from_daa = cursor.daa_score.get();
+        let pruning_point = pruning_point_header.block_hash;
+        let to_daa = pruning_point_header.daa_score;
+        if to_daa < from_daa {
+            anyhow::bail!(
+                "Cannot recover from pruned sync: invalid gap range (from_daa {from_daa} > to_daa {to_daa})"
+            );
+        }
+
+        self.record_acceptance_gap(cursor.block_hash, from_daa, pruning_point, to_daa)?;
+        let (cleared_blocks, cleared_txs) = self.purge_acceptance_gap_data(from_daa, to_daa)?;
+        info!(
+            from_daa,
+            to_daa, cleared_blocks, cleared_txs, "Acceptance recovery cleanup completed"
+        );
+
+        let new_syncer_id = syncer_id + 1;
+        let syncer = self.spawn_syncer(new_syncer_id, pruning_point_header.block_hash);
+        state.shared_state.realtime_queue_vcc.clear();
+        state.shared_state.processed_time_or_warn = Instant::now();
+        state.sync_state = SyncState::Syncing {
+            last_accepting_block: (pruning_point_header.block_hash, Default::default()),
+            syncer,
+            syncer_id: new_syncer_id,
+            target_block: (target_hash, target_blue_work),
+            sync_queue: None,
+        };
+        info!(
+            from = %from.to_hex_64(),
+            pp = %pruning_point_header.block_hash.to_hex_64(),
+            "Restarted syncer from pruning point after error"
+        );
+        Ok(true)
+    }
+
+    fn record_acceptance_gap(
+        &self,
+        from_hash: [u8; 32],
+        from_daa: u64,
+        to_hash: [u8; 32],
+        to_daa: u64,
+    ) -> anyhow::Result<()> {
+        loop {
+            let mut wtx = self.tx_keyspace.write_tx()?;
+            self.acceptance_gaps_partition.add_gap_wtx(
+                &mut wtx,
+                DbAcceptanceGap {
+                    from_daa,
+                    to_daa,
+                    from_block_hash: from_hash,
+                    to_block_hash: to_hash,
+                },
+            );
+            self.metadata_partition
+                .remove_latest_accepting_block_cursor(&mut wtx)?;
+            if wtx.commit()?.is_ok() {
+                break;
+            } else {
+                debug!("Conflict detected while persisting acceptance gap");
+            }
+        }
+        Ok(())
+    }
+
+    // TODO: I'm not convinced by the introduced complexity here
+    // I assume the number of data here should be low
+    fn purge_acceptance_gap_data(&self, from_daa: u64, to_daa: u64) -> anyhow::Result<(u64, u64)> {
+        if from_daa > to_daa {
+            anyhow::bail!("Invalid acceptance gap range (from_daa {from_daa} > to_daa {to_daa})");
+        }
+        let rtx = self.tx_keyspace.read_tx();
+        let mut blocks = Vec::new();
+        let upper = to_daa.saturating_add(1);
+        for key in self.daa_index_partition.iter_lt(&rtx, upper) {
+            let key = key?;
+            let daa = key.daa_score.get();
+            if daa < from_daa {
+                continue;
+            }
+            blocks.push((daa, key.block_hash));
+        }
+        drop(rtx);
+
+        if blocks.is_empty() {
+            return Ok((0, 0));
+        }
+
+        let mut cleared_blocks = 0u64;
+        let mut cleared_txs = 0u64;
+        const BATCH: usize = 256;
+        for chunk in blocks.chunks(BATCH) {
+            loop {
+                let mut wtx = self.tx_keyspace.write_tx()?;
+                let mut chunk_blocks = 0u64;
+                let mut chunk_txs = 0u64;
+                for (daa, block_hash) in chunk {
+                    let Some(tracked_tx_ids) = self
+                        .accepting_block_to_tx_id_partition
+                        .remove_wtx(&mut wtx, block_hash)?
+                    else {
+                        continue;
+                    };
+                    chunk_blocks += 1;
+                    for tx_id in tracked_tx_ids.as_ref() {
+                        let Some(key) = self.tx_id_to_acceptance_partition.key_by_tx_id(tx_id)?
+                        else {
+                            continue;
+                        };
+                        let _ = self
+                            .tx_id_to_acceptance_partition
+                            .clear_acceptance_wtx(&mut wtx, &key)?;
+                        self.pending_sender_resolution_partition.remove_wtx(
+                            &mut wtx,
+                            &PendingResolutionKey {
+                                accepting_daa_score: (*daa).into(),
+                                tx_id: *tx_id,
+                            },
+                        );
+                        chunk_txs += 1;
+                    }
+                }
+                if wtx.commit()?.is_ok() {
+                    cleared_blocks += chunk_blocks;
+                    cleared_txs += chunk_txs;
+                    break;
+                } else {
+                    debug!("Conflict detected while clearing acceptance window");
+                }
+            }
+        }
+
+        Ok((cleared_blocks, cleared_txs))
     }
 
     fn spawn_syncer(&self, syncer_id: u64, from: [u8; 32]) -> Sender<NotificationAck> {

--- a/indexer-actors/src/virtual_chain_processor.rs
+++ b/indexer-actors/src/virtual_chain_processor.rs
@@ -536,10 +536,14 @@ impl VirtualProcessor {
         }
 
         self.record_acceptance_gap(cursor.block_hash, from_daa, pruning_point, to_daa)?;
-        let (cleared_blocks, cleared_txs) = self.purge_acceptance_gap_data(from_daa, to_daa)?;
+
+        let PurgeAcceptanceGapReport {
+            block_count,
+            txs_count,
+        } = self.purge_acceptance_gap_data(from_daa, to_daa)?;
         info!(
             from_daa,
-            to_daa, cleared_blocks, cleared_txs, "Acceptance recovery cleanup completed"
+            to_daa, block_count, txs_count, "Acceptance recovery cleanup completed"
         );
 
         let new_syncer_id = syncer_id + 1;
@@ -592,7 +596,11 @@ impl VirtualProcessor {
 
     // TODO: I'm not convinced by the introduced complexity here
     // I assume the number of data here should be low
-    fn purge_acceptance_gap_data(&self, from_daa: u64, to_daa: u64) -> anyhow::Result<(u64, u64)> {
+    fn purge_acceptance_gap_data(
+        &self,
+        from_daa: u64,
+        to_daa: u64,
+    ) -> anyhow::Result<PurgeAcceptanceGapReport> {
         if from_daa > to_daa {
             anyhow::bail!("Invalid acceptance gap range (from_daa {from_daa} > to_daa {to_daa})");
         }
@@ -610,13 +618,18 @@ impl VirtualProcessor {
         drop(rtx);
 
         if blocks.is_empty() {
-            return Ok((0, 0));
+            return Ok(PurgeAcceptanceGapReport {
+                block_count: 0,
+                txs_count: 0,
+            });
         }
 
         let mut cleared_blocks = 0u64;
         let mut cleared_txs = 0u64;
         const BATCH: usize = 256;
         for chunk in blocks.chunks(BATCH) {
+            const MAX_RETRY_CIRCUIT_BREAKER: u8 = u8::MAX;
+            let mut iteration_count = 0;
             loop {
                 let mut wtx = self.tx_keyspace.write_tx()?;
                 let mut chunk_blocks = 0u64;
@@ -654,10 +667,24 @@ impl VirtualProcessor {
                 } else {
                     debug!("Conflict detected while clearing acceptance window");
                 }
+
+                if iteration_count == MAX_RETRY_CIRCUIT_BREAKER {
+                    // not sure how to handle this.
+                    // throwing or not: will leave dangling data
+                    anyhow::bail!(
+                        "Failed to clear acceptance window after {} tries.",
+                        MAX_RETRY_CIRCUIT_BREAKER
+                    );
+                }
+
+                iteration_count += 1;
             }
         }
 
-        Ok((cleared_blocks, cleared_txs))
+        Ok(PurgeAcceptanceGapReport {
+            block_count: cleared_blocks,
+            txs_count: cleared_txs,
+        })
     }
 
     fn spawn_syncer(&self, syncer_id: u64, from: [u8; 32]) -> Sender<NotificationAck> {
@@ -1119,6 +1146,11 @@ impl From<Cursor> for DbCursor {
             daa_score: value.daa_score.into(),
         }
     }
+}
+
+struct PurgeAcceptanceGapReport {
+    pub block_count: u64,
+    pub txs_count: u64,
 }
 
 type DaaScore = u64;

--- a/indexer-actors/src/virtual_chain_processor/message.rs
+++ b/indexer-actors/src/virtual_chain_processor/message.rs
@@ -9,7 +9,7 @@ pub enum RealTimeVccNotification {
     Connected {
         sink: [u8; 32],
         sink_blue_work: BlueWorkType,
-        pp: [u8; 32],
+        pp_header: CompactHeader,
     },
     Disconnected,
     Shutdown,
@@ -26,6 +26,11 @@ pub enum SyncVccNotification {
     VirtualChain {
         syncer_id: u64,
         virtual_chain: GetVirtualChainFromBlockResponse,
+    },
+    Pruned {
+        syncer_id: u64,
+        from: [u8; 32],
+        err: String,
     },
     Stopped {
         syncer_id: u64,

--- a/indexer-actors/src/virtual_chain_syncer.rs
+++ b/indexer-actors/src/virtual_chain_syncer.rs
@@ -1,9 +1,10 @@
-use crate::data_source::{Command, Request};
+use crate::data_source::{Command, Request, RequestError};
 use crate::util::ToHex64;
 use crate::virtual_chain_processor::SyncVccNotification;
 use anyhow::Context;
 use futures_util::FutureExt;
-use tracing::{error, info};
+use std::time::Duration;
+use tracing::{error, info, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationAck {
@@ -17,6 +18,12 @@ pub struct VirtualChainSyncer {
     vcc_tx: flume::Sender<SyncVccNotification>,
     commands_tx: workflow_core::channel::Sender<Command>,
     ack_rx: workflow_core::channel::Receiver<NotificationAck>,
+}
+
+enum VirtualChainRequestOutcome {
+    Sent,
+    Pruned,
+    Stopped,
 }
 
 impl VirtualChainSyncer {
@@ -40,56 +47,78 @@ impl VirtualChainSyncer {
         let mut from = self.from;
         info!(from = %from.to_hex_64(), "Starting VirtualChainSyncer");
 
-        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-
-        self.commands_tx
-            .send(Command::Request(Request::RequestVirtualChain {
-                vc_from: from,
-                response_channel: resp_tx,
-            }))
-            .await?;
-        tokio::select! {
-            r = resp_rx => {
-                let r = r??;
-                from = r.added_chain_block_hashes.last().map(|h| h.as_bytes()).unwrap_or(from);
-                self.vcc_tx.send(SyncVccNotification::VirtualChain {syncer_id: self.syncer_id,virtual_chain: r}).context("Failed to send first virtual chain")?;
-            },
-            r = self.ack_rx.recv().fuse() => {
-                let r = r.context("Failed to receive first ack")?;
-                match r {
-                    NotificationAck::Continue => unreachable!(),
-                    NotificationAck::Stop => {
-                        return Ok(())
-                    }
-                }
+        match self.request_and_send(&mut from).await? {
+            VirtualChainRequestOutcome::Sent => {}
+            VirtualChainRequestOutcome::Pruned | VirtualChainRequestOutcome::Stopped => {
+                return Ok(());
             }
         }
         loop {
             match self.ack_rx.recv().await.context("Failed to receive ack")? {
                 NotificationAck::Stop => return Ok(()),
-                NotificationAck::Continue => {
-                    let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-                    self.commands_tx
-                        .send(Command::Request(Request::RequestVirtualChain {
-                            vc_from: from,
-                            response_channel: resp_tx,
-                        }))
-                        .await
-                        .context("Failed to send request")?;
-                    tokio::select! {
-                        r = resp_rx => {
-                            let r = r.context("Failed to receive response")?.context("Failed response")?;
-                            from = r.added_chain_block_hashes.last().map(|h| h.as_bytes()).unwrap_or(from);
-                            self.vcc_tx.send_async(SyncVccNotification::VirtualChain {syncer_id: self.syncer_id,virtual_chain: r}).await.context("Failed to send virtual chain")?;
-                        },
-                        r = self.ack_rx.recv().fuse() => {
-                            let r = r.context("Failed to receive ack")?;
-                            match r {
-                                NotificationAck::Continue => unreachable!(),
-                                NotificationAck::Stop => {
-                                    return Ok(())
-                                }
-                            }
+                NotificationAck::Continue => match self.request_and_send(&mut from).await? {
+                    VirtualChainRequestOutcome::Sent => {}
+                    VirtualChainRequestOutcome::Pruned | VirtualChainRequestOutcome::Stopped => {
+                        return Ok(());
+                    }
+                },
+            }
+        }
+    }
+
+    async fn request_and_send(
+        &self,
+        from: &mut [u8; 32],
+    ) -> anyhow::Result<VirtualChainRequestOutcome> {
+        loop {
+            let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+            self.commands_tx
+                .send(Command::Request(Request::RequestVirtualChain {
+                    vc_from: *from,
+                    response_channel: resp_tx,
+                }))
+                .await
+                .context("Failed to send request")?;
+            tokio::select! {
+                r = resp_rx => {
+                    let r = r.context("Failed to receive response")?;
+                    match r {
+                        Ok(r) => {
+                            *from = r.added_chain_block_hashes.last().map(|h| h.as_bytes()).unwrap_or(*from);
+                            self.vcc_tx
+                                .send_async(SyncVccNotification::VirtualChain {
+                                    syncer_id: self.syncer_id,
+                                    virtual_chain: r,
+                                })
+                                .await
+                                .context("Failed to send virtual chain")?;
+                            return Ok(VirtualChainRequestOutcome::Sent);
+                        }
+                        Err(RequestError::Pruned) => {
+                            _ = self
+                                .vcc_tx
+                                .send_async(SyncVccNotification::Pruned {
+                                    syncer_id: self.syncer_id,
+                                    from: *from,
+                                    err: "pruned".to_string(),
+                                })
+                                .await;
+                            return Ok(VirtualChainRequestOutcome::Pruned);
+                        }
+                        Err(RequestError::ShuttingDown) => return Ok(VirtualChainRequestOutcome::Stopped),
+                        Err(RequestError::RpcError(err)) => {
+                            warn!(error = %err, "Virtual chain request failed, retrying");
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                            continue;
+                        }
+                    }
+                },
+                r = self.ack_rx.recv().fuse() => {
+                    let r = r.context("Failed to receive ack")?;
+                    match r {
+                        NotificationAck::Continue => unreachable!(),
+                        NotificationAck::Stop => {
+                            return Ok(VirtualChainRequestOutcome::Stopped)
                         }
                     }
                 }

--- a/indexer-db/src/processing.rs
+++ b/indexer-db/src/processing.rs
@@ -1,3 +1,4 @@
+pub mod acceptance_gaps;
 pub mod accepting_block_to_txs;
 
 pub mod tx_id_to_acceptance;

--- a/indexer-db/src/processing/acceptance_gaps.rs
+++ b/indexer-db/src/processing/acceptance_gaps.rs
@@ -1,0 +1,107 @@
+use anyhow::Result;
+use arrayref::array_ref;
+use fjall::{PartitionCreateOptions, ReadTransaction, WriteTransaction};
+
+#[derive(Debug, Copy, Clone)]
+pub struct AcceptanceGap {
+    pub from_daa: u64,
+    pub to_daa: u64,
+    pub from_block_hash: [u8; 32],
+    pub to_block_hash: [u8; 32],
+}
+
+#[derive(Clone)]
+pub struct AcceptanceGapsPartition(fjall::TxPartition);
+
+impl AcceptanceGapsPartition {
+    pub fn new(keyspace: &fjall::TxKeyspace) -> Result<Self> {
+        Ok(Self(keyspace.open_partition(
+            "acceptance_gaps",
+            PartitionCreateOptions::default().block_size(64 * 1024),
+        )?))
+    }
+
+    fn key_bytes(to_daa: u64, to_block_hash: [u8; 32]) -> [u8; 40] {
+        let mut key = [0u8; 40];
+        key[..8].copy_from_slice(&to_daa.to_be_bytes());
+        key[8..].copy_from_slice(&to_block_hash);
+        key
+    }
+
+    fn value_bytes(from_daa: u64, from_block_hash: [u8; 32]) -> [u8; 40] {
+        let mut value = [0u8; 40];
+        value[..8].copy_from_slice(&from_daa.to_be_bytes());
+        value[8..].copy_from_slice(&from_block_hash);
+        value
+    }
+
+    pub fn add_gap_wtx(&self, wtx: &mut WriteTransaction, gap: AcceptanceGap) {
+        let key = Self::key_bytes(gap.to_daa, gap.to_block_hash);
+        let value = Self::value_bytes(gap.from_daa, gap.from_block_hash);
+        wtx.insert(&self.0, key, value);
+    }
+
+    pub fn add_gap(&self, gap: AcceptanceGap) -> Result<()> {
+        let key = Self::key_bytes(gap.to_daa, gap.to_block_hash);
+        let value = Self::value_bytes(gap.from_daa, gap.from_block_hash);
+        self.0.insert(key, value)?;
+        Ok(())
+    }
+
+    pub fn remove_gap_wtx(
+        &self,
+        wtx: &mut WriteTransaction,
+        to_daa: u64,
+        to_block_hash: &[u8; 32],
+    ) {
+        let key = Self::key_bytes(to_daa, *to_block_hash);
+        wtx.remove(&self.0, key);
+    }
+
+    pub fn get_all_gaps_rtx(
+        &self,
+        rtx: &ReadTransaction,
+    ) -> impl DoubleEndedIterator<Item = Result<AcceptanceGap>> + '_ {
+        rtx.iter(&self.0).map(|item| {
+            let (key, value) = item?;
+            if key.len() == 40 && value.len() == 40 {
+                let to_daa = u64::from_be_bytes(*array_ref![key, 0, 8]);
+                let to_block_hash = *array_ref![key, 8, 32];
+                let from_daa = u64::from_be_bytes(*array_ref![value, 0, 8]);
+                let from_block_hash = *array_ref![value, 8, 32];
+                Ok(AcceptanceGap {
+                    from_daa,
+                    to_daa,
+                    from_block_hash,
+                    to_block_hash,
+                })
+            } else {
+                Err(anyhow::anyhow!(
+                    "Invalid key/value lengths in acceptance_gaps partition"
+                ))
+            }
+        })
+    }
+
+    pub fn get_all_gaps(&self) -> impl DoubleEndedIterator<Item = Result<AcceptanceGap>> + '_ {
+        self.0.inner().iter().map(|item| {
+            let (key, value) = item?;
+            if key.len() == 40 && value.len() == 40 {
+                let to_daa = u64::from_be_bytes(*array_ref![key, 0, 8]);
+                let to_block_hash = *array_ref![key, 8, 32];
+                let from_daa = u64::from_be_bytes(*array_ref![value, 0, 8]);
+                let from_block_hash = *array_ref![value, 8, 32];
+                Ok(AcceptanceGap {
+                    from_daa,
+                    to_daa,
+                    from_block_hash,
+                    to_block_hash,
+                })
+            } else {
+                Err(anyhow::anyhow!(
+                    "Invalid key/value lengths in acceptance_gaps partition"
+                ))
+            }
+        })
+    }
+}

--- a/indexer-db/src/processing/acceptance_gaps.rs
+++ b/indexer-db/src/processing/acceptance_gaps.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use arrayref::array_ref;
 use fjall::{PartitionCreateOptions, ReadTransaction, WriteTransaction};
+use zerocopy::big_endian::U64 as U64_BE;
+use zerocopy::little_endian::U64 as U64_LE;
+use zerocopy::{FromBytes, Immutable, IntoBytes, TryFromBytes, Unaligned};
 
 #[derive(Debug, Copy, Clone)]
 pub struct AcceptanceGap {
@@ -8,6 +10,20 @@ pub struct AcceptanceGap {
     pub to_daa: u64,
     pub from_block_hash: [u8; 32],
     pub to_block_hash: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Immutable, FromBytes, IntoBytes, Unaligned)]
+#[repr(C)]
+struct AcceptanceGapKey {
+    pub to_daa: U64_BE,
+    pub to_block_hash: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Immutable, FromBytes, IntoBytes, Unaligned)]
+#[repr(C)]
+struct AcceptanceGapValue {
+    pub from_daa: U64_LE,
+    pub from_block_hash: [u8; 32],
 }
 
 #[derive(Clone)]
@@ -21,30 +37,30 @@ impl AcceptanceGapsPartition {
         )?))
     }
 
-    fn key_bytes(to_daa: u64, to_block_hash: [u8; 32]) -> [u8; 40] {
-        let mut key = [0u8; 40];
-        key[..8].copy_from_slice(&to_daa.to_be_bytes());
-        key[8..].copy_from_slice(&to_block_hash);
-        key
+    fn make_key(to_daa: u64, to_block_hash: [u8; 32]) -> AcceptanceGapKey {
+        AcceptanceGapKey {
+            to_daa: to_daa.into(),
+            to_block_hash,
+        }
     }
 
-    fn value_bytes(from_daa: u64, from_block_hash: [u8; 32]) -> [u8; 40] {
-        let mut value = [0u8; 40];
-        value[..8].copy_from_slice(&from_daa.to_be_bytes());
-        value[8..].copy_from_slice(&from_block_hash);
-        value
+    fn make_value(from_daa: u64, from_block_hash: [u8; 32]) -> AcceptanceGapValue {
+        AcceptanceGapValue {
+            from_daa: from_daa.into(),
+            from_block_hash,
+        }
     }
 
     pub fn add_gap_wtx(&self, wtx: &mut WriteTransaction, gap: AcceptanceGap) {
-        let key = Self::key_bytes(gap.to_daa, gap.to_block_hash);
-        let value = Self::value_bytes(gap.from_daa, gap.from_block_hash);
-        wtx.insert(&self.0, key, value);
+        let key = Self::make_key(gap.to_daa, gap.to_block_hash);
+        let value = Self::make_value(gap.from_daa, gap.from_block_hash);
+        wtx.insert(&self.0, key.as_bytes(), value.as_bytes());
     }
 
     pub fn add_gap(&self, gap: AcceptanceGap) -> Result<()> {
-        let key = Self::key_bytes(gap.to_daa, gap.to_block_hash);
-        let value = Self::value_bytes(gap.from_daa, gap.from_block_hash);
-        self.0.insert(key, value)?;
+        let key = Self::make_key(gap.to_daa, gap.to_block_hash);
+        let value = Self::make_value(gap.from_daa, gap.from_block_hash);
+        self.0.insert(key.as_bytes(), value.as_bytes())?;
         Ok(())
     }
 
@@ -54,8 +70,8 @@ impl AcceptanceGapsPartition {
         to_daa: u64,
         to_block_hash: &[u8; 32],
     ) {
-        let key = Self::key_bytes(to_daa, *to_block_hash);
-        wtx.remove(&self.0, key);
+        let key = Self::make_key(to_daa, *to_block_hash);
+        wtx.remove(&self.0, key.as_bytes());
     }
 
     pub fn get_all_gaps_rtx(
@@ -64,44 +80,36 @@ impl AcceptanceGapsPartition {
     ) -> impl DoubleEndedIterator<Item = Result<AcceptanceGap>> + '_ {
         rtx.iter(&self.0).map(|item| {
             let (key, value) = item?;
-            if key.len() == 40 && value.len() == 40 {
-                let to_daa = u64::from_be_bytes(*array_ref![key, 0, 8]);
-                let to_block_hash = *array_ref![key, 8, 32];
-                let from_daa = u64::from_be_bytes(*array_ref![value, 0, 8]);
-                let from_block_hash = *array_ref![value, 8, 32];
-                Ok(AcceptanceGap {
-                    from_daa,
-                    to_daa,
-                    from_block_hash,
-                    to_block_hash,
-                })
-            } else {
-                Err(anyhow::anyhow!(
-                    "Invalid key/value lengths in acceptance_gaps partition"
-                ))
-            }
+            let key = AcceptanceGapKey::try_read_from_bytes(key.as_bytes())
+                .map_err(|_| anyhow::anyhow!("Invalid key length in acceptance_gaps partition"))?;
+            let value =
+                AcceptanceGapValue::try_read_from_bytes(value.as_bytes()).map_err(|_| {
+                    anyhow::anyhow!("Invalid value length in acceptance_gaps partition")
+                })?;
+            Ok(AcceptanceGap {
+                from_daa: value.from_daa.get(),
+                to_daa: key.to_daa.get(),
+                from_block_hash: value.from_block_hash,
+                to_block_hash: key.to_block_hash,
+            })
         })
     }
 
     pub fn get_all_gaps(&self) -> impl DoubleEndedIterator<Item = Result<AcceptanceGap>> + '_ {
         self.0.inner().iter().map(|item| {
             let (key, value) = item?;
-            if key.len() == 40 && value.len() == 40 {
-                let to_daa = u64::from_be_bytes(*array_ref![key, 0, 8]);
-                let to_block_hash = *array_ref![key, 8, 32];
-                let from_daa = u64::from_be_bytes(*array_ref![value, 0, 8]);
-                let from_block_hash = *array_ref![value, 8, 32];
-                Ok(AcceptanceGap {
-                    from_daa,
-                    to_daa,
-                    from_block_hash,
-                    to_block_hash,
-                })
-            } else {
-                Err(anyhow::anyhow!(
-                    "Invalid key/value lengths in acceptance_gaps partition"
-                ))
-            }
+            let key = AcceptanceGapKey::try_read_from_bytes(key.as_bytes())
+                .map_err(|_| anyhow::anyhow!("Invalid key length in acceptance_gaps partition"))?;
+            let value =
+                AcceptanceGapValue::try_read_from_bytes(value.as_bytes()).map_err(|_| {
+                    anyhow::anyhow!("Invalid value length in acceptance_gaps partition")
+                })?;
+            Ok(AcceptanceGap {
+                from_daa: value.from_daa.get(),
+                to_daa: key.to_daa.get(),
+                from_block_hash: value.from_block_hash,
+                to_block_hash: key.to_block_hash,
+            })
         })
     }
 }

--- a/indexer-db/src/processing/tx_id_to_acceptance.rs
+++ b/indexer-db/src/processing/tx_id_to_acceptance.rs
@@ -166,6 +166,27 @@ impl TxIDToAcceptancePartition {
         })
     }
 
+    pub fn clear_acceptance_wtx(
+        &self,
+        wtx: &mut WriteTransaction,
+        k: &AcceptanceKey,
+    ) -> anyhow::Result<LookupOutput> {
+        let old_value = wtx.fetch_update(&self.0, k.as_bytes(), |old_value| {
+            let old_value = old_value?;
+            let mut v = Vec::with_capacity(old_value.len());
+            v.extend_from_slice(AcceptanceValueHeader::new_zeroed().as_bytes());
+            v.extend_from_slice(old_value[size_of::<AcceptanceValueHeader>()..].as_ref());
+            Some(v.into())
+        })?;
+        Ok(match old_value {
+            None => LookupOutput::KeyDoesNotExist,
+            Some(value) if value.len() > size_of::<AcceptanceValueHeader>() => {
+                LookupOutput::KeysExistsWithEntries
+            }
+            Some(_) => LookupOutput::KeyExistsNoEntries,
+        })
+    }
+
     pub fn resolve_entries_wtx(
         &self,
         wtx: &mut WriteTransaction,

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -26,6 +26,7 @@ use indexer_db::messages::self_stash::{SelfStashByOwnerPartition, TxIdToSelfStas
 use indexer_db::metadata::MetadataPartition;
 use indexer_db::migration::apply_migrations;
 use indexer_db::processing::accepting_block_to_txs::AcceptingBlockToTxIDPartition;
+use indexer_db::processing::acceptance_gaps::AcceptanceGapsPartition;
 use indexer_db::processing::pending_senders::PendingSenderResolutionPartition;
 use indexer_db::processing::tx_id_to_acceptance::TxIDToAcceptancePartition;
 use kaspa_rpc_core::RpcBlueWorkType;
@@ -82,6 +83,7 @@ async fn main() -> anyhow::Result<()> {
     let tx_id_to_acceptance_partition = TxIDToAcceptancePartition::new(&tx_keyspace)?;
     let block_compact_header_partition = BlockCompactHeaderPartition::new(&tx_keyspace)?;
     let acceptance_to_tx_id_partition = AcceptingBlockToTxIDPartition::new(&tx_keyspace)?;
+    let acceptance_gaps_partition = AcceptanceGapsPartition::new(&tx_keyspace)?;
     let pending_sender_resolution_partition = PendingSenderResolutionPartition::new(&tx_keyspace)?;
     let handshake_by_sender_partition = HandshakeBySenderPartition::new(&tx_keyspace)?;
     let payment_by_sender_partition = PaymentBySenderPartition::new(&tx_keyspace)?;
@@ -164,6 +166,8 @@ async fn main() -> anyhow::Result<()> {
         .command_tx(command_channel.sender.clone())
         .tx_keyspace(tx_keyspace.clone())
         .metadata_partition(metadata_partition.clone())
+        .acceptance_gaps_partition(acceptance_gaps_partition.clone())
+        .daa_index_partition(block_daa_index_partition.clone())
         .tx_id_to_acceptance_partition(tx_id_to_acceptance_partition.clone())
         .accepting_block_to_tx_id_partition(acceptance_to_tx_id_partition.clone())
         .pending_sender_resolution_partition(pending_sender_resolution_partition.clone())

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -25,8 +25,8 @@ use indexer_db::messages::payment::{
 use indexer_db::messages::self_stash::{SelfStashByOwnerPartition, TxIdToSelfStashPartition};
 use indexer_db::metadata::MetadataPartition;
 use indexer_db::migration::apply_migrations;
-use indexer_db::processing::accepting_block_to_txs::AcceptingBlockToTxIDPartition;
 use indexer_db::processing::acceptance_gaps::AcceptanceGapsPartition;
+use indexer_db::processing::accepting_block_to_txs::AcceptingBlockToTxIDPartition;
 use indexer_db::processing::pending_senders::PendingSenderResolutionPartition;
 use indexer_db::processing::tx_id_to_acceptance::TxIDToAcceptancePartition;
 use kaspa_rpc_core::RpcBlueWorkType;


### PR DESCRIPTION
- add `acceptance_gaps` partition 
- fetch the pp header on connect and pass `pp_header` through notifications
- classify missing header RPC error as `Pruned`
- on "pruned sync" (recovery needed), record the gap, purge acceptance data and pending sender entries in that range, and restart from the pruning point

Still some flaws:
- pruning point fetched from connect currently is used as a "restart checkpoint" for underlying service (vcc + block processor) but it can be pruned a few seconds later when processed by workers, need guidance here. possible path: let workers / processors fetch the pp themselves at runtime. (increased complexity)
=> Possible shortcut, add a safety window of "a few block" after pp and use that as a checkpoint

Things I'd like to improve:
- `purge_acceptance_gap_data` becomes too complex, or at least I find it too complex